### PR TITLE
Added transparency to PictoChat

### DIFF
--- a/enchat3.lua
+++ b/enchat3.lua
@@ -325,8 +325,8 @@ local textToBlit = function(_str, onlyString, initTxt, initBg, _checkPos) -- ret
 		else
 			output = output..str:sub(p,p)
 		end
-		txcolorout = txcolorout..tx
-		bgcolorout = bgcolorout..bg
+		txcolorout = txcolorout..(tx == " " and origTX or tx)
+		bgcolorout = bgcolorout..(bg == " " and origBG or bg)
 	end
 	local checkMod = 0
 	local modifyCheck = function()
@@ -398,7 +398,7 @@ local textToBlit = function(_str, onlyString, initTxt, initBg, _checkPos) -- ret
 	if onlyString then
 		return output, checkMod
 	else
-		return {output, txcolorout:gsub(" ",origTX), bgcolorout:gsub(" ",origBG)}, checkMod
+		return {output, txcolorout, bgcolorout}, checkMod
 	end
 end
 

--- a/enchat3.lua
+++ b/enchat3.lua
@@ -1101,7 +1101,7 @@ local genRenderLog = function()
 	for a = 1, #log do
 		termsetCursorPos(1,1)
 		if UIconf.nameDecolor then
-			local dcName = textToBlit(table.concat({log[a].prefix,log[a].name,log[a].suffix}), true)
+			local dcName = textToBlit(table.concat({log[a].prefix,log[a].name,log[a].suffix}), true, palette.txt, palette.bg)
 			local dcMessage = textToBlit(log[a].message)
 			prebuff = {
 				dcName..dcMessage[1],
@@ -1109,7 +1109,7 @@ local genRenderLog = function()
 				toblit[palette.bg]:rep(#dcName)..dcMessage[3]
 			}
 		else
-			prebuff = textToBlit(table.concat({log[a].prefix,"&r~r",log[a].name,"&r~r",log[a].suffix,"&r~r",log[a].message}))
+			prebuff = textToBlit(table.concat({log[a].prefix,"&r~r",log[a].name,"&r~r",log[a].suffix,"&r~r",log[a].message}), false, palette.txt, palette.bg)
 		end
 		if (log[a].frame == 0) and (canvas and enchatSettings.doNotif) then
 			if not (log[a].name == "" and log[a].message == " ") then

--- a/enchat3.lua
+++ b/enchat3.lua
@@ -1096,20 +1096,18 @@ local genRenderLog = function()
 	local buff, prebuff, maxLength
 	local scrollToBottom = scroll == maxScroll
 	renderlog = {}
-	termsetTextColor(palette.txt)
-	termsetBackgroundColor(palette.bg)
 	for a = 1, #log do
 		termsetCursorPos(1,1)
 		if UIconf.nameDecolor then
-			local dcName = textToBlit(table.concat({log[a].prefix,log[a].name,log[a].suffix}), true, palette.txt, palette.bg)
-			local dcMessage = textToBlit(log[a].message)
+			local dcName = textToBlit(table.concat({log[a].prefix,log[a].name,log[a].suffix}), true, toblit[palette.txt], toblit[palette.bg])
+			local dcMessage = textToBlit(log[a].message, false, toblit[palette.txt], toblit[palette.bg])
 			prebuff = {
 				dcName..dcMessage[1],
 				toblit[palette.chevron]:rep(#dcName)..dcMessage[2],
 				toblit[palette.bg]:rep(#dcName)..dcMessage[3]
 			}
 		else
-			prebuff = textToBlit(table.concat({log[a].prefix,"&r~r",log[a].name,"&r~r",log[a].suffix,"&r~r",log[a].message}), false, palette.txt, palette.bg)
+			prebuff = textToBlit(table.concat({log[a].prefix,"&r~r",log[a].name,"&r~r",log[a].suffix,"&r~r",log[a].message}), false, toblit[palette.txt], toblit[palette.bg])
 		end
 		if (log[a].frame == 0) and (canvas and enchatSettings.doNotif) then
 			if not (log[a].name == "" and log[a].message == " ") then

--- a/enchat3.lua
+++ b/enchat3.lua
@@ -398,7 +398,7 @@ local textToBlit = function(_str, onlyString, initTxt, initBg, _checkPos) -- ret
 	if onlyString then
 		return output, checkMod
 	else
-		return {output, txcolorout, bgcolorout}, checkMod
+		return {output, txcolorout:gsub(" ",origTX), bgcolorout:gsub(" ",origBG)}, checkMod
 	end
 end
 


### PR DESCRIPTION
Before, pictochat would have a black background for all images, but now, all unused dots are transparent, thanks to a change in textToBlit() to change all " " TXT/BG characters into the current TXT/BG colors.